### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Report an issue to help us improve GSConnect
+labels: 
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem. You can drag-and-drop or cut-and-paste images directly into this edit window, to include them in your report.
+
+**Debug output**
+If you have been able to reproduce the problem with debugging enabled (see [instructions in the wiki](wiki/Debugging)), paste any log messages related to this issue between the two ``` lines below.
+
+```
+
+```
+
+**System Details (please complete the following information):**
+ - GSConnect version: [e.g. 16, 15, ... (displayed in the GSConnect "About" window)]
+   - Installed from: [e.g. extensions.gnome.org, GitHub Release download, distro package, ...]
+ - GNOME/Shell version: [e.g. 3.30, 3.28, ...]
+ - Distro/Release: [e.g. Ubuntu 18.04, Fedora 29, Arch, ...]
+
+**GSConnect environment (if applicable):**
+ - Paired Device(s): [e.g. Galaxy Note 8, Pixel 2, Honor 9, ...]
+ - KDE Connect app version: [e.g. ]
+ - Plugin(s): [if the issue only occurs when using certain plugin(s)]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request-or-idea.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-or-idea.md
@@ -1,0 +1,22 @@
+---
+name: Feature request or idea
+about: Suggest an improvement to GSConnect
+labels: 
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**System Details (please complete the following information):**
+ - GSConnect version: [e.g. 16, 15, ... (displayed in the GSConnect "About" window)]
+   - Installed from: [e.g. extensions.gnome.org, GitHub Release download, distro package, ...]
+
+**Additional context**
+Add any other context for your suggestion here, including screenshots if applicable.


### PR DESCRIPTION
I thought it might be helpful, when users open new Issues, to prompt for a little more structure and give them an idea of what details would be most helpful.